### PR TITLE
fix: res.write throwing error if body is null

### DIFF
--- a/src/Router.ts
+++ b/src/Router.ts
@@ -196,8 +196,12 @@ function reply(route: Route, res: Response, req: Request) {
   const body = applyTemplate(route.getResponseBody(), req);
 
   res.writeHead(route.getResponseStatusCode(), headers);
+  const data = encodeBody(req, headers, body);
 
-  res.write(encodeBody(req, headers, body));
+  if (data !== null) {
+    res.write(data);
+  }
+
   res.end();
 }
 /**

--- a/test/specs/index.spec.ts
+++ b/test/specs/index.spec.ts
@@ -698,6 +698,15 @@ describe('index', () => {
         arrayValue: [null, { something: 'else' }],
       });
     });
+
+    it('should not set a response if no response is provided and not json', async () => {
+      const STATUS_CODE = 200;
+      sb.delete('/').setResponseStatusCode(STATUS_CODE);
+
+      expect(
+        await request('/', { method: 'DELETE', responseType: 'text' }),
+      ).toReplyWith(STATUS_CODE);
+    });
   });
 
   describe('Retain Calls', () => {


### PR DESCRIPTION
If mocking non JSON response, setting response body to null throws
error TypeError [ERR_STREAM_NULL_VALUES]: May not write null values to stream
on res.write